### PR TITLE
Update Common.php

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -253,8 +253,8 @@ if ( ! function_exists('get_config'))
 				}
 			}
 		}
-
-		return $_config[0] =& $config;
+		$_config[0] =& $config;
+		return $_config[0];
 	}
 }
 


### PR DESCRIPTION
Severity: Notice
Message: Only variable references should be returned by reference
Filename: core/Common.php
Line Number: 257