### PR TITLE
Update Loader.php

### DIFF
--- a/application/third_party/MX/Loader.php
+++ b/application/third_party/MX/Loader.php
@@ -128,7 +128,7 @@ class MX_Loader extends CI_Loader
 	}
 	
 	/** Load a module library **/
-	public function library($library, $params = NULL, $object_name = NULL) {
+	public function library($library = '', $params = NULL, $object_name = NULL) {
 		
 		if (is_array($library)) return $this->libraries($library);		
 		


### PR DESCRIPTION
Severity: Warning

Message: Declaration of MX_Loader::library($library, $params = NULL, $object_name = NULL) should be compatible with CI_Loader::library($library = '', $params = NULL, $object_name = NULL)

Filename: MX/Loader.php

Line Number: 131